### PR TITLE
Use msgpack.Marshal

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -206,11 +206,7 @@ func (m *Message) DecodeMsgpack(d *msgpack.Decoder) error {
 }
 
 func msgpackMarshal(m *Message) ([]byte, error) {
-	var buf bytes.Buffer
-	if err := msgpack.NewEncoder(&buf).Encode(m); err != nil {
-		return nil, errors.Wrap(err, `failed to encode msgpack`)
-	}
-	return buf.Bytes(), nil
+	return msgpack.Marshal(m)
 }
 
 func jsonMarshal(m *Message) ([]byte, error) {


### PR DESCRIPTION
This is more optimized after
https://github.com/lestrrat/go-msgpack/commit/22afa03a71cace2a39b3950efe4ea2ff93663713

Slashes allocations by ~~4 allocs/op~~ 5 allocs/op